### PR TITLE
Add Catalan translation

### DIFF
--- a/src/constants/translations/ca-CA.ts
+++ b/src/constants/translations/ca-CA.ts
@@ -1,0 +1,87 @@
+import { Translation } from 'types/Translation';
+import en_US from './en-US';
+
+const ca_CA = {
+  // DASHBOARD
+  ALL: 'Tots',
+  CREDIT: 'Crèdit',
+  DEBIT: 'Dèbit',
+  RECENT_TRANSACTIONS: 'Transaccions recents',
+  MY_ACCOUNTS: 'Els meus comptes',
+
+  // ADD ACCOUNT
+  ADD_ACCOUNT: 'Afegir compte',
+  ACCOUNT_NAME: 'Nom del compte',
+  INITIAL_AMOUNT: 'Import inicial',
+  CREATE_ACCOUNT: 'Crea compte',
+
+  // EDIT ACCOUNT
+  EDIT_ACCOUNT: 'Editar compte',
+  UPDATE_ACCOUNT: 'Actualitza el compte',
+
+  // ACCOUNT DETAILS
+  ACCOUNT_DETAILS: 'Detalls del compte',
+  CURRENT_BALANCE: 'Import actual',
+  INITIAL_BALANCE: 'Import inicial',
+  DELETE_ACCOUNT: 'Esborrar compte?',
+  DELETE_ACCOUNT_INFO:
+    'Això suprimirà permanentment el compte {{accountName}} incloses les transaccions enllaçades {{transactionCount}}.',
+
+  // NEW TRANSACTION
+  NEW_TRANSACTION: 'Nova transacció',
+  CREATE_TRANSACTION: 'Crear transacció',
+  CATEGORY: 'Categoria',
+  SOURCE_ACCOUNT: 'Compte d'origen',
+  DESTINATION_ACCOUNT: 'Compte de destinació',
+  TRANSFER: 'Transferència',
+  SHORT_DESCRIPTION: 'Curta descripció',
+  AMOUNT: 'Import',
+
+  // EDIT TRANSACTION
+  EDIT_TRANSACTION: 'Editar la transacció',
+  UPDATE_TRANSACTION: 'Actualitzar la transacció',
+
+  // TRANSACTION DETAILS
+  TRANSACTION_DETAILS: 'Detalls de la transacció',
+  ACCOUNT: 'Compte',
+  TRANSACTION_DATE: 'Data de la transacció',
+  TRANSACTION_TIME: 'Hora de la transacció',
+  DATE_CREATED: 'Data de creació',
+  DATE_UPDATED: 'Data d'actualització',
+  DELETE_TRANSACTION: 'Suprimeix la transacció?',
+  DELETE_TRANSACTION_INFO:
+    'Això suprimirà permanentment el registre de la transacció.',
+  KEEP: 'Mantenir',
+  DELETE: 'Suprimeix',
+
+  // Transactions
+  TRANSACTIONS: 'Transaccions',
+  EXPORT: 'Exporta',
+
+  // SETTINGS
+  SETTINGS: 'Configuració',
+  TRANSLATION_NAME: 'Català (CA)',
+  CURRENCY: 'Moneda',
+  LANGUAGE: 'Llenguatge',
+  THEME: 'Tema',
+  THEME_LIGHT: 'Clar',
+  THEME_DARK: 'Fosc',
+  THEME_WASABI: 'Wasabi',
+
+  // Insights
+  INSIGHTS: 'Insights',
+
+  // Filters
+  FILTERS: 'Filtres',
+  SEARCH: 'Cercar',
+  SEARCH_TERM: 'Terme de cerca',
+  SEARCH_DESCRIPTION:
+    'Això cerca text similar a la descripció o categoria d'una transacció.',
+  DATE_RANGE: 'Interval de dates',
+  SHOW_ALL: 'Mostrar tots',
+  TRANSACTION_TYPE: 'Tipus de transacció',
+  RESET_FILTER: 'Restableix',
+  APPLY_FILTER: 'Aplicar filtres',
+};
+
+export default ca_CA;

--- a/src/constants/translations/ca-CA.ts
+++ b/src/constants/translations/ca-CA.ts
@@ -1,7 +1,8 @@
 import { Translation } from 'types/Translation';
 import en_US from './en-US';
 
-const ca_CA = {
+const ca_CA: Translation = {
+  ...en_US,
   // DASHBOARD
   ALL: 'Tots',
   CREDIT: 'Crèdit',
@@ -31,7 +32,7 @@ const ca_CA = {
   NEW_TRANSACTION: 'Nova transacció',
   CREATE_TRANSACTION: 'Crear transacció',
   CATEGORY: 'Categoria',
-  SOURCE_ACCOUNT: 'Compte d'origen',
+  SOURCE_ACCOUNT: "Compte d'origen",
   DESTINATION_ACCOUNT: 'Compte de destinació',
   TRANSFER: 'Transferència',
   SHORT_DESCRIPTION: 'Curta descripció',
@@ -47,7 +48,7 @@ const ca_CA = {
   TRANSACTION_DATE: 'Data de la transacció',
   TRANSACTION_TIME: 'Hora de la transacció',
   DATE_CREATED: 'Data de creació',
-  DATE_UPDATED: 'Data d'actualització',
+  DATE_UPDATED: "Data d'actualització",
   DELETE_TRANSACTION: 'Suprimeix la transacció?',
   DELETE_TRANSACTION_INFO:
     'Això suprimirà permanentment el registre de la transacció.',
@@ -76,7 +77,7 @@ const ca_CA = {
   SEARCH: 'Cercar',
   SEARCH_TERM: 'Terme de cerca',
   SEARCH_DESCRIPTION:
-    'Això cerca text similar a la descripció o categoria d'una transacció.',
+    "Això cerca text similar a la descripció o categoria d'una transacció.",
   DATE_RANGE: 'Interval de dates',
   SHOW_ALL: 'Mostrar tots',
   TRANSACTION_TYPE: 'Tipus de transacció',

--- a/src/constants/translations/index.ts
+++ b/src/constants/translations/index.ts
@@ -1,4 +1,5 @@
 import ar_AR from './ar-AR';
+import ca_CA from './ca-CA';
 import cs_CZ from './cs-CZ';
 import en_US from './en-US';
 import es_MX from './es-MX';
@@ -13,6 +14,7 @@ import id_ID from './id-ID';
 
 export const TRANSLATIONS = {
   'ar-AR': ar_AR,
+  'ca-CA': ca_CA,
   'cs-CZ': cs_CZ,
   'en-US': en_US,
   'es-MX': es_MX,


### PR DESCRIPTION
Cherry-picked from jerameel/sushi#73 by @retiolus (never merged upstream — the project has been unmaintained since Feb 2023).

The original PR only added `ca-CA.ts` but never registered it in `src/constants/translations/index.ts`, so it would not have shown up in the Settings language picker. Added that registration here as a second commit.

Upstream PR: https://github.com/jerameel/sushi/pull/73