### PR TITLE
Add French translation

### DIFF
--- a/src/constants/translations/fr-FR.ts
+++ b/src/constants/translations/fr-FR.ts
@@ -1,0 +1,86 @@
+import { Translation } from 'types/Translation';
+import en_US from './en-US';
+
+const fr_FR: Translation = {
+  ...en_US,
+  // DASHBOARD
+  CREDIT: 'Crédit',
+  DEBIT: 'Débit',
+  RECENT_TRANSACTIONS: 'Transactions récentes',
+  MY_ACCOUNTS: 'Mes comptes',
+
+  // ADD ACCOUNT
+  ADD_ACCOUNT: 'Ajouter un Compte',
+  ACCOUNT_NAME: 'Intitulé du Compte',
+  INITIAL_AMOUNT: 'Montant Initial',
+  CREATE_ACCOUNT: 'Créer un Compte',
+
+  // EDIT ACCOUNT
+  EDIT_ACCOUNT: 'Modifier le Compte',
+  UPDATE_ACCOUNT: 'Mettre à jour le Compte',
+
+  // ACCOUNT DETAILS
+  ACCOUNT_DETAILS: 'Détails du Compte',
+  INITIAL_BALANCE: 'Balance Initiale',
+  DELETE_ACCOUNT: 'Supprimer le Compte ?',
+  DELETE_ACCOUNT_INFO:
+    'Cela va supprimer définitivement le compte {{accountName}} ainsi que {{transactionCount}} transactions liées.',
+
+  // NEW TRANSACTION
+  NEW_TRANSACTION: 'Nouvelle Transaction',
+  CREATE_TRANSACTION: 'Ajouter une Transaction',
+  CATEGORY: 'Catégorie',
+  SOURCE_ACCOUNT: 'Compte d'origine',
+  DESTINATION_ACCOUNT: 'Compte de destination',
+  TRANSFER: 'Transférer',
+  SHORT_DESCRIPTION: 'Description Courte',
+  AMOUNT: 'Montant',
+
+  // EDIT TRANSACTION
+  EDIT_TRANSACTION: 'Modifier la Transaction',
+  UPDATE_TRANSACTION: 'Mettre à jour la Transaction',
+
+  // TRANSACTION DETAILS
+  TRANSACTION_DETAILS: 'Détails de la Transaction',
+  ACCOUNT: 'Compte',
+  DATE_CREATED: 'Date de Création',
+  DATE_UPDATED: 'Date de Modification',
+  DELETE_TRANSACTION: 'Supprimer la Transaction ?',
+  DELETE_TRANSACTION_INFO: 'Cela va supprimer définitivement la Transaction',
+  KEEP: 'Conserver',
+  DELETE: 'Supprimer',
+
+  // Transactions
+  TRANSACTIONS: 'Transactions',
+  SEARCH: 'Rechercher',
+  DATE_RANGE: 'Plage de date',
+  SHOW_ALL: 'Tout montrer',
+  EXPORT: 'Exporter',
+
+  // SETTINGS
+  SETTINGS: 'Réglages',
+  TRANSLATION_NAME: 'Français (FR)',
+  CURRENCY: 'Monnaie',
+  LANGUAGE: 'Langue',
+  THEME: 'Thème',
+  THEME_LIGHT: 'Clair',
+  THEME_DARK: 'Sombre',
+  THEME_WASABI: 'Wasabi',
+
+  // Insights
+  INSIGHTS: 'Insights',
+
+  // Filters
+  FILTERS: 'Filtres',
+  SEARCH: 'Rechercher',
+  SEARCH_TERM: 'Rechercher un terme',
+  SEARCH_DESCRIPTION:
+    'La recherche se fait sur des termes similaires dans la description, catégorie ou transaction.',
+  DATE_RANGE: 'Plage de date',
+  SHOW_ALL: 'Tout montrer',
+  TRANSACTION_TYPE: 'Type de Transaction',
+  RESET_FILTER: 'Réinitialiser',
+  APPLY_FILTER: 'Appliquer les filtres',
+};
+
+export default fr_FR;

--- a/src/constants/translations/fr-FR.ts
+++ b/src/constants/translations/fr-FR.ts
@@ -30,7 +30,7 @@ const fr_FR: Translation = {
   NEW_TRANSACTION: 'Nouvelle Transaction',
   CREATE_TRANSACTION: 'Ajouter une Transaction',
   CATEGORY: 'Catégorie',
-  SOURCE_ACCOUNT: 'Compte d'origine',
+  SOURCE_ACCOUNT: "Compte d'origine",
   DESTINATION_ACCOUNT: 'Compte de destination',
   TRANSFER: 'Transférer',
   SHORT_DESCRIPTION: 'Description Courte',
@@ -52,9 +52,6 @@ const fr_FR: Translation = {
 
   // Transactions
   TRANSACTIONS: 'Transactions',
-  SEARCH: 'Rechercher',
-  DATE_RANGE: 'Plage de date',
-  SHOW_ALL: 'Tout montrer',
   EXPORT: 'Exporter',
 
   // SETTINGS

--- a/src/constants/translations/index.ts
+++ b/src/constants/translations/index.ts
@@ -3,6 +3,7 @@ import cs_CZ from './cs-CZ';
 import en_US from './en-US';
 import es_MX from './es-MX';
 import fil_PH from './fil-PH';
+import fr_FR from './fr-FR';
 import it_IT from './it-IT';
 import pl_PL from './pl-PL';
 import pt_BR from './pt-BR';
@@ -17,6 +18,7 @@ export const TRANSLATIONS = {
   'en-US': en_US,
   'es-MX': es_MX,
   'fil-PH': fil_PH,
+  'fr-FR': fr_FR,
   'it-IT': it_IT,
   'pl-PL': pl_PL,
   'pt-BR': pt_BR,


### PR DESCRIPTION
Cherry-picked from jerameel/sushi#74 by @jp-clerc (never merged upstream — the project has been unmaintained since Feb 2023).

Same gap as the Catalan PR: the original only added `fr-FR.ts` without registering it in `src/constants/translations/index.ts`. Added that registration here as a second commit.

Upstream PR: https://github.com/jerameel/sushi/pull/74