### PR TITLE
Fix date picker off-by-one / timezone bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android:storybook": "ENVFILE=.env.storybook npm run android",
     "ios": "react-native run-ios --simulator=\"iPhone 14\"",
     "start": "react-native start",
-    "test": "jest ./*.unit.test.* --coverage",
+    "test": "TZ=UTC jest ./*.unit.test.* --coverage",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "generate": "plop",
     "android:debug": "npm run android:bundle-js && npm run android:build-debug-apk",

--- a/src/components/module/DatePicker/view.tsx
+++ b/src/components/module/DatePicker/view.tsx
@@ -8,6 +8,7 @@ import { Calendar } from 'react-native-calendars';
 import eachDayOfInterval from 'date-fns/eachDayOfInterval';
 import format from 'date-fns/format';
 import Button from 'components/base/Button/view';
+import { applyDayToDate } from 'utils/applyDayToDate';
 
 const DatePicker = (props: DatePickerPrivateProps) => {
   const {
@@ -127,7 +128,7 @@ const DatePicker = (props: DatePickerPrivateProps) => {
                     : {}),
                 }}
                 onDayPress={(day) => {
-                  const newDate = new Date(day.dateString);
+                  const newDate = applyDayToDate(startDate, day);
                   // reset or start date
                   if ((startDate && endDate) || !startDate || !setEndDate) {
                     setStartDate(newDate);

--- a/src/utils/applyDayToDate.ts
+++ b/src/utils/applyDayToDate.ts
@@ -1,0 +1,24 @@
+export const applyDayToDate = (date: Date | null, day: any): Date => {
+  const newDate = new Date();
+
+  // Apply day in local timezone
+  newDate.setFullYear(day.year);
+  newDate.setMonth(day.month - 1); // month in `Date` object is 0-based
+  newDate.setDate(day.day);
+
+  if (date) {
+    // Apply hours in UTC
+    newDate.setUTCHours(
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    );
+  } else {
+    // Manually zero out hours by applying offset (so it's 00:00 in user's timezone)
+    newDate.setHours(0);
+    newDate.setMinutes(newDate.getTimezoneOffset(), 0, 0);
+  }
+
+  return newDate;
+};

--- a/src/utils/applyDayToDate.unit.test.ts
+++ b/src/utils/applyDayToDate.unit.test.ts
@@ -1,0 +1,100 @@
+import { applyDayToDate } from './applyDayToDate';
+
+describe('applyDayToDate', () => {
+  const realDate = global.Date; // Save the original Date object
+
+  function stubDateWithTimezone(timezoneOffsetMinutes: number) {
+    (global as any).Date = class extends realDate {
+      // Override getTimezoneOffset to simulate the timezone
+      getTimezoneOffset() {
+        return -timezoneOffsetMinutes; // Return the mock offset (in minutes)
+      }
+    };
+  }
+
+  afterEach(() => {
+    global.Date = realDate; // Restore the original Date object after each test
+  });
+
+  const dayToApply = {
+    dateString: '2023-04-01',
+    day: 1,
+    month: 4,
+    timestamp: 1734134400000,
+    year: 2023,
+  };
+
+  describe('when timezone is UTC', () => {
+    describe('when date is present', () => {
+      const date = new Date('2020-12-25T16:30:00.000Z');
+
+      it('applies date in local timezone and does not touch hours', () => {
+        const result = applyDayToDate(date, dayToApply);
+
+        expect(result).toEqual(new Date('2023-04-01T16:30:00.000Z'));
+        expect(result).toEqual(new Date('2023-04-01T16:30:00.000-00:00'));
+      });
+    });
+
+    describe('when date is absent', () => {
+      it('applies date in local timezone and zeroes hours out', () => {
+        const result = applyDayToDate(null, dayToApply);
+
+        expect(result).toEqual(new Date('2023-04-01T00:00:00.000Z'));
+        expect(result).toEqual(new Date('2023-04-01T00:00:00.000-00:00'));
+      });
+    });
+  });
+
+  describe('when timezone is west of UTC', () => {
+    beforeEach(() => {
+      stubDateWithTimezone(-3 * 60);
+    });
+
+    describe('when date is present', () => {
+      const date = new Date('2020-12-25T16:30:00.000Z');
+
+      it('applies date in local timezone and does not touch hours', () => {
+        const result = applyDayToDate(date, dayToApply);
+
+        expect(result).toEqual(new Date('2023-04-01T16:30:00.000Z'));
+        expect(result).toEqual(new Date('2023-04-01T13:30:00.000-03:00'));
+      });
+    });
+
+    describe('when date is absent', () => {
+      it('applies date in local timezone and zeroes hours out', () => {
+        const result = applyDayToDate(null, dayToApply);
+
+        expect(result).toEqual(new Date('2023-04-01T03:00:00.000Z'));
+        expect(result).toEqual(new Date('2023-04-01T00:00:00.000-03:00'));
+      });
+    });
+  });
+
+  describe('when timezone is east of UTC', () => {
+    beforeEach(() => {
+      stubDateWithTimezone(+8 * 60);
+    });
+
+    describe('when date is present', () => {
+      const date = new Date('2020-12-25T16:30:00.000Z');
+
+      it('applies date in local timezone and does not touch hours', () => {
+        const result = applyDayToDate(date, dayToApply);
+
+        expect(result).toEqual(new Date('2023-04-01T16:30:00.000Z'));
+        expect(result).toEqual(new Date('2023-04-02T00:30:00.000+08:00'));
+      });
+    });
+
+    describe('when date is absent', () => {
+      it('applies date in local timezone and zeroes hours out', () => {
+        const result = applyDayToDate(null, dayToApply);
+
+        expect(result).toEqual(new Date('2023-03-31T16:00:00.000Z'));
+        expect(result).toEqual(new Date('2023-04-01T00:00:00.000+08:00'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Cherry-picked from jerameel/sushi#93 by @rhian-cs (never merged upstream — the project has been unmaintained since Feb 2023).

Fixes #41 (date picker selecting the day before the one tapped). Adds `applyDayToDate` which builds the new date in the local timezone and preserves the previously-set time-of-day, plus unit tests covering UTC and both timezone directions.

A competing upstream fix, jerameel/sushi#72, was reviewed and not used: its date fix (`new Date(year, month-1, day)`) drops the existing time-of-day and its diff also bundles unrelated pt-BR translation strings for UI (Filters, Wasabi theme) that don't exist on `main`.

Upstream PR: https://github.com/jerameel/sushi/pull/93