### PR TITLE
Add Swahili (sw-TZ) translation

### DIFF
--- a/src/constants/translations/index.ts
+++ b/src/constants/translations/index.ts
@@ -10,6 +10,7 @@ import ru_RU from './ru-RU';
 import uk_UA from './uk-UA';
 import de_DE from './de-DE';
 import id_ID from './id-ID';
+import sw_TZ from './sw-TZ';
 
 export const TRANSLATIONS = {
   'ar-AR': ar_AR,
@@ -24,4 +25,5 @@ export const TRANSLATIONS = {
   'uk-UA': uk_UA,
   'de-DE': de_DE,
   'id-ID': id_ID,
+  'sw-TZ': sw_TZ,
 };

--- a/src/constants/translations/sw-TZ.ts
+++ b/src/constants/translations/sw-TZ.ts
@@ -1,0 +1,87 @@
+import { Translation } from 'types/Translation';
+import en_US from './en-US';
+
+const sw_TZ: Translation = {
+  ...en_US,
+  // DASHBOARD
+  ALL: 'Zote',
+  CREDIT: 'Mkopo',
+  DEBIT: 'Malipo',
+  RECENT_TRANSACTIONS: 'Miamala ya Hivi Karibuni',
+  MY_ACCOUNTS: 'Akaunti Zangu',
+
+  // ADD ACCOUNT
+  ADD_ACCOUNT: 'Ongeza Akaunti',
+  ACCOUNT_NAME: 'Jina la Akaunti',
+  INITIAL_AMOUNT: 'Kiasi cha Awali',
+  CREATE_ACCOUNT: 'Fungua Akaunti',
+
+  // EDIT ACCOUNT
+  EDIT_ACCOUNT: 'Hariri Akaunti',
+  UPDATE_ACCOUNT: 'Sasisha Akaunti',
+
+  // ACCOUNT DETAILS
+  ACCOUNT_DETAILS: 'Maelezo ya Akaunti',
+  CURRENT_BALANCE: 'Salio la Sasa',
+  INITIAL_BALANCE: 'Salio la Awali',
+  DELETE_ACCOUNT: 'Futa Akaunti?',
+  DELETE_ACCOUNT_INFO:
+    'Hatua hii itafuta kabisa akaunti ya {{accountName}} pamoja na miamala {{transactionCount}} iliyounganishwa nayo.',
+
+  // NEW TRANSACTION
+  NEW_TRANSACTION: 'Muamala Mpya',
+  CREATE_TRANSACTION: 'Fanya Muamala',
+  CATEGORY: 'Kundi',
+  SOURCE_ACCOUNT: 'Akaunti ya Chanzo',
+  DESTINATION_ACCOUNT: 'Akaunti ya Mpokeaji',
+  TRANSFER: 'Hamisha',
+  SHORT_DESCRIPTION: 'Maelezo Mafupi',
+  AMOUNT: 'Kiasi',
+
+  // EDIT TRANSACTION
+  EDIT_TRANSACTION: 'Hariri Muamala',
+  UPDATE_TRANSACTION: 'Sasisha Muamala',
+
+  // TRANSACTION DETAILS
+  TRANSACTION_DETAILS: 'Maelezo ya Muamala',
+  ACCOUNT: 'Akaunti',
+  TRANSACTION_DATE: 'Tarehe ya Muamala',
+  TRANSACTION_TIME: 'Muda wa Muamala',
+  DATE_CREATED: 'Tarehe ya Kuundwa',
+  DATE_UPDATED: 'Tarehe ya Kusasishwa',
+  DELETE_TRANSACTION: 'Futa Muamala?',
+  DELETE_TRANSACTION_INFO: 'Hatua hii itafuta kabisa rekodi ya muamala huu.',
+  KEEP: 'Weka',
+  DELETE: 'Futa',
+
+  // Transactions
+  TRANSACTIONS: 'Miamala',
+  EXPORT: 'Hamisha Nje',
+
+  // SETTINGS
+  SETTINGS: 'Mipangilio',
+  TRANSLATION_NAME: 'Kiswahili (TZ)',
+  CURRENCY: 'Sarafu',
+  LANGUAGE: 'Lugha',
+  THEME: 'Mandhari',
+  THEME_LIGHT: 'Angavu',
+  THEME_DARK: 'Giza',
+  THEME_WASABI: 'Wasabi',
+
+  // Insights
+  INSIGHTS: 'Tathmini',
+
+  // Filters
+  FILTERS: 'Vichujio',
+  SEARCH: 'Tafuta',
+  SEARCH_TERM: 'Neno la Kutafuta',
+  SEARCH_DESCRIPTION:
+    'Hutafuta maneno yanayofanana katika maelezo au kundi la muamala.',
+  DATE_RANGE: 'Kipindi cha Tarehe',
+  SHOW_ALL: 'Onyesha Zote',
+  TRANSACTION_TYPE: 'Aina ya Muamala',
+  RESET_FILTER: 'Weka Upya',
+  APPLY_FILTER: 'Tumia Vichujio',
+};
+
+export default sw_TZ;


### PR DESCRIPTION
Adds a Swahili translation, following the same pattern as the existing fr-FR/ca-CA translation PRs: new `sw-TZ.ts` file plus registration in `src/constants/translations/index.ts`.

Unlike the other translation PRs on this fork, this one has no upstream source PR — it's newly drafted here. All 56 keys from `en-US.ts` are covered (verified against `translations.unit.test.ts`'s completeness check).

**Please review for accuracy** — this should get a pass from a native Swahili speaker before merging; happy to take corrections.