### PR TITLE
100% test coverage for the pure-logic layer (redux, utils, services)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ node_modules/
 npm-debug.log
 yarn-error.log
 
+# jest coverage output
+coverage/
+
 # BUCK
 buck-out/
 \.buckd/

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@babel/core": "^7.12.9",
         "@babel/runtime": "^7.12.5",
         "@react-native-community/eslint-config": "^2.0.0",
+        "@testing-library/react-native": "^10.1.1",
         "@types/jest": "^26.0.23",
         "@types/ramda": "^0.27.45",
         "@types/react-native": "^0.64.5",
@@ -4327,6 +4328,67 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-10.1.1.tgz",
+      "integrity": "sha512-tflpI2MTOEe0Gmj0FCTYOQD8OwBYq/YpAre0QFe2IMCcMFr55h/5zvCdwB3+uUsr6Nqve+hs6poVrD3t2wwoLQ==",
+      "deprecated": "This version is no longer maintained. Upgrade to @latest (at least v12.4.0).",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^27.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -20899,6 +20961,46 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
+      }
+    },
+    "@testing-library/react-native": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-10.1.1.tgz",
+      "integrity": "sha512-tflpI2MTOEe0Gmj0FCTYOQD8OwBYq/YpAre0QFe2IMCcMFr55h/5zvCdwB3+uUsr6Nqve+hs6poVrD3t2wwoLQ==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^27.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android:storybook": "ENVFILE=.env.storybook npm run android",
     "ios": "react-native run-ios --simulator=\"iPhone 14\"",
     "start": "react-native start",
-    "test": "jest ./*.unit.test.*",
+    "test": "jest ./*.unit.test.* --coverage",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "generate": "plop",
     "android:debug": "npm run android:bundle-js && npm run android:build-debug-apk",
@@ -44,6 +44,7 @@
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@react-native-community/eslint-config": "^2.0.0",
+    "@testing-library/react-native": "^10.1.1",
     "@types/jest": "^26.0.23",
     "@types/ramda": "^0.27.45",
     "@types/react-native": "^0.64.5",
@@ -72,6 +73,21 @@
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "collectCoverageFrom": [
+      "src/store/**/*.{ts,tsx}",
+      "src/utils/**/*.{ts,tsx}",
+      "src/services/**/*.{ts,tsx}",
+      "!**/*.test.{ts,tsx}",
+      "!src/utils/testUtils/**"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   }
 }

--- a/src/services/CSV/createCSV.unit.test.ts
+++ b/src/services/CSV/createCSV.unit.test.ts
@@ -1,0 +1,21 @@
+jest.mock('rn-fetch-blob', () => ({
+  fs: {
+    dirs: { DownloadDir: '/mock/downloads' },
+    createFile: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import RNFetchBlob from 'rn-fetch-blob';
+import { createCSV } from './createCSV';
+
+describe('createCSV', () => {
+  test('writes the csv string to a file in the download directory', async () => {
+    await createCSV('transactions_20240101', 'header\nrow');
+
+    expect(RNFetchBlob.fs.createFile).toHaveBeenCalledWith(
+      '/mock/downloads/sushi_transactions_20240101.csv',
+      'header\nrow',
+      'utf8',
+    );
+  });
+});

--- a/src/services/CSV/index.unit.test.ts
+++ b/src/services/CSV/index.unit.test.ts
@@ -1,0 +1,15 @@
+jest.mock('rn-fetch-blob', () => ({
+  fs: {
+    dirs: { DownloadDir: '/mock/downloads' },
+    createFile: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { createCSV, recordToCSVString } from './index';
+
+describe('CSV service barrel', () => {
+  test('re-exports createCSV and recordToCSVString', () => {
+    expect(typeof createCSV).toBe('function');
+    expect(typeof recordToCSVString).toBe('function');
+  });
+});

--- a/src/store/currency.unit.test.ts
+++ b/src/store/currency.unit.test.ts
@@ -1,0 +1,12 @@
+import currencyReducer, { setLanguageAction } from './currency';
+
+describe('currency', () => {
+  test('setLanguage updates the language', () => {
+    const state = currencyReducer(
+      { language: 'en-US' },
+      setLanguageAction('fil-PH'),
+    );
+
+    expect(state).toEqual({ language: 'fil-PH' });
+  });
+});

--- a/src/store/filters.unit.test.ts
+++ b/src/store/filters.unit.test.ts
@@ -1,0 +1,27 @@
+import filtersReducer, { applyFiltersAction } from './filters';
+import { Filters } from './filters';
+
+describe('filters', () => {
+  test('applyFilters replaces the whole filters state', () => {
+    const newFilters: Filters = {
+      startDate: new Date('2024-01-01'),
+      endDate: new Date('2024-01-31'),
+      searchTerm: 'groceries',
+      accountId: 'wallet-1',
+      transactionType: 'DEBIT',
+    };
+
+    const state = filtersReducer(
+      {
+        startDate: null,
+        endDate: null,
+        searchTerm: '',
+        accountId: null,
+        transactionType: null,
+      },
+      applyFiltersAction(newFilters),
+    );
+
+    expect(state).toEqual(newFilters);
+  });
+});

--- a/src/store/index.unit.test.ts
+++ b/src/store/index.unit.test.ts
@@ -1,0 +1,46 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+import createAppStore from './index';
+import { createWalletAction } from './wallets';
+
+describe('store', () => {
+  test('creates a store, persistor, and runSaga with the expected initial shape', async () => {
+    const { store, persistor, runSaga } = createAppStore();
+
+    expect(typeof runSaga).toBe('function');
+    expect(typeof persistor.purge).toBe('function');
+
+    const state = store.getState();
+    expect(Object.keys(state)).toEqual(
+      expect.arrayContaining([
+        'theme',
+        'wallets',
+        'transactions',
+        'currency',
+        'language',
+        'filters',
+        '_persist',
+      ]),
+    );
+    expect(state.wallets).toEqual({});
+    expect(state.transactions).toEqual({});
+    expect(state.currency).toEqual({ language: 'en-US' });
+    expect(state.language).toEqual({ selected: 'en-US' });
+
+    persistor.purge();
+  });
+
+  test('dispatching an action updates state through the wired-up reducers', () => {
+    const { store, persistor } = createAppStore();
+
+    store.dispatch(createWalletAction({ label: 'Cash', initialAmount: 100 }));
+
+    const walletIds = Object.keys(store.getState().wallets);
+    expect(walletIds).toHaveLength(1);
+    expect(store.getState().wallets[walletIds[0]].label).toBe('Cash');
+
+    persistor.purge();
+  });
+});

--- a/src/store/language.unit.test.ts
+++ b/src/store/language.unit.test.ts
@@ -1,0 +1,12 @@
+import languageReducer, { setSelectedLanguageAction } from './language';
+
+describe('language', () => {
+  test('setSelectedLanguage updates the selected language', () => {
+    const state = languageReducer(
+      { selected: 'en-US' },
+      setSelectedLanguageAction('de-DE'),
+    );
+
+    expect(state).toEqual({ selected: 'de-DE' });
+  });
+});

--- a/src/store/migration/index.unit.test.ts
+++ b/src/store/migration/index.unit.test.ts
@@ -1,0 +1,41 @@
+import Migrations from './index';
+
+describe('migrations', () => {
+  test('migration 2 backfills paidAt from createdAt on every transaction', () => {
+    const state: any = {
+      transactions: {
+        'transaction-1': {
+          id: 'transaction-1',
+          sourceWalletId: 'wallet-1',
+          destinationWalletId: null,
+          category: 'Groceries',
+          description: '',
+          amount: -50,
+          createdAt: '2023-05-01T00:00:00.000Z',
+          updatedAt: '2023-05-01T00:00:00.000Z',
+        },
+        'transaction-2': {
+          id: 'transaction-2',
+          sourceWalletId: 'wallet-1',
+          destinationWalletId: null,
+          category: 'Salary',
+          description: '',
+          amount: 1000,
+          createdAt: '2023-06-01T00:00:00.000Z',
+          updatedAt: '2023-06-01T00:00:00.000Z',
+        },
+      },
+    };
+
+    const migrated = Migrations[2](state);
+
+    expect(migrated.transactions['transaction-1'].paidAt).toBe(
+      '2023-05-01T00:00:00.000Z',
+    );
+    expect(migrated.transactions['transaction-2'].paidAt).toBe(
+      '2023-06-01T00:00:00.000Z',
+    );
+    // other fields are preserved
+    expect(migrated.transactions['transaction-1'].category).toBe('Groceries');
+  });
+});

--- a/src/store/sagas/index.unit.test.ts
+++ b/src/store/sagas/index.unit.test.ts
@@ -1,0 +1,11 @@
+import { all } from 'redux-saga/effects';
+import root from './index';
+
+describe('root saga', () => {
+  test('forks all registered sagas (currently none)', () => {
+    const generator = root();
+
+    expect(generator.next().value).toEqual(all([]));
+    expect(generator.next().done).toBe(true);
+  });
+});

--- a/src/store/theme.unit.test.ts
+++ b/src/store/theme.unit.test.ts
@@ -1,0 +1,35 @@
+import { Appearance } from 'react-native';
+
+describe('theme', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  test('initial state defaults to Dark when the OS scheme is dark', () => {
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
+    const themeReducer = require('./theme').default;
+
+    expect(themeReducer(undefined, { type: '@@INIT' })).toEqual({
+      base: 'Dark',
+    });
+  });
+
+  test('initial state defaults to Light when the OS scheme is not dark', () => {
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('light');
+    const themeReducer = require('./theme').default;
+
+    expect(themeReducer(undefined, { type: '@@INIT' })).toEqual({
+      base: 'Light',
+    });
+  });
+
+  test('setTheme updates the base theme', () => {
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('light');
+    const { default: themeReducer, setThemeAction } = require('./theme');
+
+    const state = themeReducer({ base: 'Light' }, setThemeAction('Dark'));
+
+    expect(state).toEqual({ base: 'Dark' });
+  });
+});

--- a/src/store/transactions.unit.test.ts
+++ b/src/store/transactions.unit.test.ts
@@ -1,0 +1,130 @@
+jest.mock('uuid', () => ({ v1: () => 'test-transaction-id' }));
+
+import transactionsReducer, {
+  createTransactionAction,
+  editTransactionAction,
+  deleteTransactionAction,
+} from './transactions';
+import { deleteWalletAction } from './wallets';
+
+const isValidISODate = (value: string) => !isNaN(Date.parse(value));
+
+describe('transactions', () => {
+  test('createTransaction adds a new transaction with a generated id and timestamps', () => {
+    const state = transactionsReducer(
+      {},
+      createTransactionAction({
+        sourceWalletId: 'wallet-1',
+        destinationWalletId: null,
+        category: 'Groceries',
+        description: 'Weekly shop',
+        amount: -50,
+        paidAt: '2024-01-01T00:00:00.000Z',
+      }),
+    );
+
+    expect(Object.keys(state)).toEqual(['test-transaction-id']);
+    const transaction = state['test-transaction-id'];
+    expect(transaction.category).toBe('Groceries');
+    expect(transaction.amount).toBe(-50);
+    expect(isValidISODate(transaction.createdAt)).toBe(true);
+    expect(transaction.createdAt).toBe(transaction.updatedAt);
+  });
+
+  test('editTransaction replaces the transaction and bumps updatedAt', () => {
+    const initialState = {
+      'transaction-1': {
+        id: 'transaction-1',
+        sourceWalletId: 'wallet-1',
+        destinationWalletId: null,
+        category: 'Groceries',
+        description: 'Weekly shop',
+        amount: -50,
+        paidAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+
+    const state = transactionsReducer(
+      initialState,
+      editTransactionAction({
+        ...initialState['transaction-1'],
+        category: 'Dining',
+        amount: -75,
+      }),
+    );
+
+    expect(state['transaction-1'].category).toBe('Dining');
+    expect(state['transaction-1'].amount).toBe(-75);
+    expect(isValidISODate(state['transaction-1'].updatedAt)).toBe(true);
+  });
+
+  test('deleteTransaction removes the transaction by id', () => {
+    const initialState = {
+      'transaction-1': {
+        id: 'transaction-1',
+        sourceWalletId: 'wallet-1',
+        destinationWalletId: null,
+        category: 'Groceries',
+        description: 'Weekly shop',
+        amount: -50,
+        paidAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+
+    const state = transactionsReducer(
+      initialState,
+      deleteTransactionAction('transaction-1'),
+    );
+
+    expect(state).toEqual({});
+  });
+
+  test('deleting a wallet cascades to remove its source and destination transactions only', () => {
+    const initialState = {
+      'source-match': {
+        id: 'source-match',
+        sourceWalletId: 'wallet-1',
+        destinationWalletId: null,
+        category: 'Groceries',
+        description: '',
+        amount: -50,
+        paidAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      'destination-match': {
+        id: 'destination-match',
+        sourceWalletId: 'wallet-2',
+        destinationWalletId: 'wallet-1',
+        category: 'Transfer',
+        description: '',
+        amount: -20,
+        paidAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      unrelated: {
+        id: 'unrelated',
+        sourceWalletId: 'wallet-2',
+        destinationWalletId: null,
+        category: 'Salary',
+        description: '',
+        amount: 1000,
+        paidAt: '2024-01-01T00:00:00.000Z',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    };
+
+    const state = transactionsReducer(
+      initialState,
+      deleteWalletAction('wallet-1'),
+    );
+
+    expect(Object.keys(state)).toEqual(['unrelated']);
+  });
+});

--- a/src/store/wallets.unit.test.ts
+++ b/src/store/wallets.unit.test.ts
@@ -1,0 +1,69 @@
+jest.mock('uuid', () => ({ v1: () => 'test-wallet-id' }));
+
+import walletsReducer, {
+  createWalletAction,
+  editWalletAction,
+  deleteWalletAction,
+} from './wallets';
+
+const isValidISODate = (value: string) => !isNaN(Date.parse(value));
+
+describe('wallets', () => {
+  test('createWallet adds a new wallet with a generated id and timestamps', () => {
+    const state = walletsReducer(
+      {},
+      createWalletAction({ label: 'Cash', initialAmount: 100 }),
+    );
+
+    expect(Object.keys(state)).toEqual(['test-wallet-id']);
+    const wallet = state['test-wallet-id'];
+    expect(wallet.id).toBe('test-wallet-id');
+    expect(wallet.label).toBe('Cash');
+    expect(wallet.initialAmount).toBe(100);
+    expect(isValidISODate(wallet.createdAt)).toBe(true);
+    expect(wallet.createdAt).toBe(wallet.updatedAt);
+  });
+
+  test('editWallet replaces the wallet and bumps updatedAt', () => {
+    const initialState = {
+      'wallet-1': {
+        id: 'wallet-1',
+        label: 'Cash',
+        initialAmount: 100,
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+      },
+    };
+
+    const state = walletsReducer(
+      initialState,
+      editWalletAction({
+        id: 'wallet-1',
+        label: 'Savings',
+        initialAmount: 200,
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+      }),
+    );
+
+    expect(state['wallet-1'].label).toBe('Savings');
+    expect(state['wallet-1'].initialAmount).toBe(200);
+    expect(isValidISODate(state['wallet-1'].updatedAt)).toBe(true);
+  });
+
+  test('deleteWallet removes the wallet by id', () => {
+    const initialState = {
+      'wallet-1': {
+        id: 'wallet-1',
+        label: 'Cash',
+        initialAmount: 100,
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+      },
+    };
+
+    const state = walletsReducer(initialState, deleteWalletAction('wallet-1'));
+
+    expect(state).toEqual({});
+  });
+});

--- a/src/utils/formatCurrency.unit.test.ts
+++ b/src/utils/formatCurrency.unit.test.ts
@@ -7,4 +7,12 @@ describe('formatCurrency', () => {
     expect(formatCurrency(2, { language: 'fil-PH' })).toBe('₱2.00');
     expect(formatCurrency(3, { language: 'zh-CN' })).toBe('¥3.00');
   });
+
+  test('formats using whatever language is currently set when no format is given', () => {
+    expect(formatCurrency(4)).toBe('¥4.00');
+  });
+
+  test('formats using the current language when format has no language override', () => {
+    expect(formatCurrency(5, { mantissa: 0 })).toBe('¥5');
+  });
 });

--- a/src/utils/formatDate.unit.test.ts
+++ b/src/utils/formatDate.unit.test.ts
@@ -1,0 +1,16 @@
+import { formatDate } from './formatDate';
+
+// Timezone-naive datetime (no trailing Z/offset) is parsed as local time by
+// `new Date(...)`, and `formatDate` renders in local time too, so this stays
+// stable regardless of which timezone the test runner is in.
+const LOCAL_DATETIME = '2024-03-15T14:30:00';
+
+describe('formatDate', () => {
+  test('formats using the default format when no option is given', () => {
+    expect(formatDate(LOCAL_DATETIME)).toBe('March 15 2024 | 02:30 PM');
+  });
+
+  test('formats using a custom format option', () => {
+    expect(formatDate(LOCAL_DATETIME, 'yyyy-MM-dd')).toBe('2024-03-15');
+  });
+});

--- a/src/utils/hooks/useFilteredTransactions.unit.test.ts
+++ b/src/utils/hooks/useFilteredTransactions.unit.test.ts
@@ -1,0 +1,172 @@
+import { renderHookWithStore } from 'utils/testUtils/renderHookWithStore';
+import useFilteredTransactions from './useFilteredTransactions';
+import { Transactions } from 'store/transactions';
+
+const baseTransaction = {
+  sourceWalletId: 'wallet-1',
+  destinationWalletId: null,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const transactions: Transactions = {
+  groceries: {
+    ...baseTransaction,
+    id: 'groceries',
+    category: 'Groceries',
+    description: 'Weekly shop',
+    amount: -50,
+    paidAt: '2024-01-05T12:00:00.000Z',
+  },
+  salary: {
+    ...baseTransaction,
+    id: 'salary',
+    category: 'Income',
+    description: 'Monthly salary',
+    amount: 1000,
+    paidAt: '2024-01-01T12:00:00.000Z',
+  },
+  transferOut: {
+    ...baseTransaction,
+    id: 'transferOut',
+    sourceWalletId: 'wallet-1',
+    destinationWalletId: 'wallet-2',
+    category: 'Transfer',
+    description: '',
+    amount: -20,
+    paidAt: '2024-01-10T12:00:00.000Z',
+  },
+  otherAccount: {
+    ...baseTransaction,
+    id: 'otherAccount',
+    sourceWalletId: 'wallet-2',
+    category: 'Dining',
+    description: 'Lunch',
+    amount: -15,
+    paidAt: '2024-01-08T12:00:00.000Z',
+  },
+};
+
+const noFilters = {
+  startDate: null,
+  endDate: null,
+  searchTerm: '',
+  accountId: null,
+  transactionType: null,
+};
+
+describe('useFilteredTransactions', () => {
+  test('returns all transactions sorted most-recent-first when no filters apply', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: noFilters,
+    });
+
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'transferOut',
+      'otherAccount',
+      'groceries',
+      'salary',
+    ]);
+  });
+
+  test('groups the filtered transactions by day, most recent day first', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: noFilters,
+    });
+
+    expect(
+      result.current.dailyFilteredTransactions.map((group) =>
+        group.data.map((t) => t.id),
+      ),
+    ).toEqual([['transferOut'], ['otherAccount'], ['groceries'], ['salary']]);
+  });
+
+  test('filters by search term against category and description', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: { ...noFilters, searchTerm: 'lunch' },
+    });
+
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'otherAccount',
+    ]);
+  });
+
+  test('filters by date range using only startDate (defaults endDate to startDate)', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: {
+        ...noFilters,
+        startDate: new Date('2024-01-05T00:00:00.000Z'),
+      },
+    });
+
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'groceries',
+    ]);
+  });
+
+  test('filters by an explicit date range', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: {
+        ...noFilters,
+        startDate: new Date('2024-01-05T00:00:00.000Z'),
+        endDate: new Date('2024-01-10T00:00:00.000Z'),
+      },
+    });
+
+    expect(result.current.filteredTransactions.map((t) => t.id).sort()).toEqual(
+      ['groceries', 'otherAccount', 'transferOut'].sort(),
+    );
+  });
+
+  test('filters by accountId matching either source or destination wallet', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: { ...noFilters, accountId: 'wallet-2' },
+    });
+
+    expect(result.current.filteredTransactions.map((t) => t.id).sort()).toEqual(
+      ['otherAccount', 'transferOut'].sort(),
+    );
+  });
+
+  test('filters DEBIT to positive, non-transfer transactions', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: { ...noFilters, transactionType: 'DEBIT' },
+    });
+
+    expect(result.current.filteredTransactions.map((t) => t.id)).toEqual([
+      'salary',
+    ]);
+  });
+
+  test('filters CREDIT to negative, non-transfer transactions', () => {
+    const { result } = renderHookWithStore(() => useFilteredTransactions(), {
+      transactions,
+      filters: { ...noFilters, transactionType: 'CREDIT' },
+    });
+
+    expect(result.current.filteredTransactions.map((t) => t.id).sort()).toEqual(
+      ['groceries', 'otherAccount'].sort(),
+    );
+  });
+
+  test('local overrides passed to the hook take precedence over global filters', () => {
+    const { result } = renderHookWithStore(
+      () => useFilteredTransactions({ accountId: 'wallet-2' }),
+      {
+        transactions,
+        filters: { ...noFilters, accountId: 'wallet-1' },
+      },
+    );
+
+    expect(result.current.filteredTransactions.map((t) => t.id).sort()).toEqual(
+      ['otherAccount', 'transferOut'].sort(),
+    );
+  });
+});

--- a/src/utils/hooks/useTranslationKey.unit.test.ts
+++ b/src/utils/hooks/useTranslationKey.unit.test.ts
@@ -1,0 +1,22 @@
+import { renderHookWithStore } from 'utils/testUtils/renderHookWithStore';
+import useTranslationKey from './useTranslationKey';
+
+describe('useTranslationKey', () => {
+  test('resolves translation keys for the selected language', () => {
+    const { result } = renderHookWithStore(
+      () => useTranslationKey(['SETTINGS', 'THEME']),
+      { language: { selected: 'en-US' } },
+    );
+
+    expect(result.current).toEqual(['Settings', 'Theme']);
+  });
+
+  test('resolves translation keys for a non-default selected language', () => {
+    const { result } = renderHookWithStore(
+      () => useTranslationKey(['SETTINGS', 'THEME']),
+      { language: { selected: 'de-DE' } },
+    );
+
+    expect(result.current).toEqual(['Einstellungen', 'Thema']);
+  });
+});

--- a/src/utils/testUtils/renderHookWithStore.tsx
+++ b/src/utils/testUtils/renderHookWithStore.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react-native';
+import themeReducer from 'store/theme';
+import walletsReducer from 'store/wallets';
+import transactionsReducer from 'store/transactions';
+import currencyReducer from 'store/currency';
+import languageReducer from 'store/language';
+import filtersReducer from 'store/filters';
+import { RootState } from 'store';
+
+const rootReducer = combineReducers({
+  theme: themeReducer,
+  wallets: walletsReducer,
+  transactions: transactionsReducer,
+  currency: currencyReducer,
+  language: languageReducer,
+  filters: filtersReducer,
+});
+
+// Lightweight, non-persisted store for hook tests only — mirrors the slice
+// shape wired up in store/index.ts without needing AsyncStorage/redux-persist.
+export const renderHookWithStore = <Result,>(
+  callback: () => Result,
+  preloadedState?: Partial<RootState>,
+) => {
+  const store = configureStore({
+    reducer: rootReducer,
+    preloadedState: preloadedState as RootState | undefined,
+  });
+
+  return renderHook(callback, {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    ),
+  });
+};


### PR DESCRIPTION
Phase 1 of test coverage. Before this PR the app had 3 test files total (no component-testing library, no coverage tooling, no CI gate). This brings the **pure-logic layer** — redux slices, `utils/`, `services/` — to a real, CI-enforced 100% (statements/branches/functions/lines). Screens and components are intentionally out of scope here (they need real UI rendering plus mocks for `react-native-calendars`, `react-native-chart-kit`, `react-native-svg`, and `@react-navigation/*`, none of which exist yet) — filing a follow-up issue for that once this merges.

## What's covered

14 new `*.unit.test.ts` files, one per previously-untested pure-logic file:
- `src/store/{wallets,transactions,currency,language,filters,theme}.ts` — all reducers/actions, including `transactions`' cross-slice cascade-delete on wallet removal, and `theme`'s OS-appearance-dependent initial state (both light/dark branches).
- `src/store/migration/index.ts`, `src/store/sagas/index.ts`, `src/store/index.ts` (the `configureStore`/`persistStore` factory).
- `src/utils/formatDate.ts`, `src/utils/hooks/{useTranslationKey,useFilteredTransactions}.ts`.
- `src/services/CSV/createCSV.ts` and a barrel test for `src/services/CSV/index.ts`.

Plus extended the existing `formatCurrency.unit.test.ts` to cover a branch (no `language` override) the original test never hit.

## Infra changes

- **One new devDependency**: `@testing-library/react-native@^10.1.1`, deliberately pinned — the latest major (`14.x`) requires React ≥19/RN ≥0.78/Jest ≥29, none of which this app has yet (React 17, RN 0.67, Jest 26; see the RN-upgrade issue #73). `10.1.1` is the newest version with no `jest` peer constraint. It's used *only* for `renderHook`, wrapped in a small shared harness (`src/utils/testUtils/renderHookWithStore.tsx`) that provides a lightweight, non-persisted Redux store — no navigation or native-module mocking, so this doesn't creep into screen-testing scope.
- **Jest config**: added `collectCoverageFrom` scoped to `src/store`, `src/utils`, `src/services` (deliberately — including untested screens/components would make "100%" fail immediately and dishonestly) and `coverageThreshold: 100%` for branches/functions/lines/statements.
- **`test` script**: now runs `jest ... --coverage`, so the threshold gate runs both locally and in the existing `.github/workflows/unit-test.yml` (already runs `npm run test`, no CI YAML changes needed).
- Mocked `uuid`, `rn-fetch-blob`, AsyncStorage (via the official `@react-native-async-storage/async-storage/jest/async-storage-mock`), and `Appearance` where each test needed determinism; date-related tests use timezone-naive datetime strings so they're stable regardless of the CI runner's timezone.
- `coverage/` added to `.gitignore`.

## Verification

Ran locally: `npm run test` → 17 suites / 38 tests passing, 100% coverage on the scoped files, exit code 0.