### PR TITLE
Fix #44: TimePicker label clipping on Android 12+

### DIFF
--- a/src/components/module/TimePicker/style.ts
+++ b/src/components/module/TimePicker/style.ts
@@ -3,6 +3,10 @@ import { StyleSheet } from 'react-native';
 import { Theme } from 'store/theme';
 import { COLORS } from 'theme';
 
+// Single source of truth for the hour/minute wheel's row height — also
+// used by view.tsx's scroll-offset math, which must stay in sync with it.
+export const TIME_PICKER_ROW_HEIGHT = 48;
+
 const useStyles = (theme: Theme = DEFAULT_THEME) => {
   const colors = COLORS[theme.base];
   // const STYLES = getGlobalStyles(theme.base);
@@ -78,13 +82,15 @@ const useStyles = (theme: Theme = DEFAULT_THEME) => {
     },
     timePickerLabel: {
       fontSize: 32,
+      lineHeight: TIME_PICKER_ROW_HEIGHT,
       color: colors.PRIMARY_TEXT,
-      height: 42,
+      height: TIME_PICKER_ROW_HEIGHT,
     },
     timePickerLabelActive: {
       fontSize: 32,
+      lineHeight: TIME_PICKER_ROW_HEIGHT,
       color: colors.PRIMARY,
-      height: 42,
+      height: TIME_PICKER_ROW_HEIGHT,
     },
     timePickerSeparator: {
       justifyContent: 'center',
@@ -92,7 +98,7 @@ const useStyles = (theme: Theme = DEFAULT_THEME) => {
       paddingHorizontal: 4,
     },
     spacer: {
-      height: 42,
+      height: TIME_PICKER_ROW_HEIGHT,
     },
   });
 

--- a/src/components/module/TimePicker/view.tsx
+++ b/src/components/module/TimePicker/view.tsx
@@ -7,7 +7,7 @@ import {
   FlatList,
 } from 'react-native';
 import Text from 'components/base/Text/view';
-import useStyles from './style';
+import useStyles, { TIME_PICKER_ROW_HEIGHT } from './style';
 import { TimePickerPrivateProps } from './props';
 import { ChevronDown, X } from 'lucide-react-native';
 import { format } from 'date-fns';
@@ -15,10 +15,7 @@ import { format } from 'date-fns';
 const HOURS = [...new Array(24)].map((v, i) => `${i}`.padStart(2, '0'));
 const MINUTES = [...new Array(60)].map((v, i) => `${i}`.padStart(2, '0'));
 
-const calculateScrollOffset = (index: number) => {
-  const fixedElementHeight = 42;
-  return index * fixedElementHeight;
-};
+const calculateScrollOffset = (index: number) => index * TIME_PICKER_ROW_HEIGHT;
 
 const TimePicker = (props: TimePickerPrivateProps) => {
   const {


### PR DESCRIPTION
Fixes #44.

## Root cause

`src/components/module/TimePicker/style.ts`'s `timePickerLabel`/`timePickerLabelActive` styles rendered 32sp digits (the hour/minute wheel) in a `height: 42` box with **no `lineHeight`** — borderline-too-tight for the font's real ascent/descent under normal conditions, and pushed over the edge by Android 12's (API 31+) font-metric/padding changes. This matches the exact reported device (Android 12, Sony Xperia 5III) precisely.

The `42` was also a magic number duplicated in **4 places** — `timePickerLabel.height`, `timePickerLabelActive.height`, `spacer.height`, and `view.tsx`'s `calculateScrollOffset`'s local `fixedElementHeight` — that all had to stay manually in sync for the wheel's tap-to-scroll positioning to line up with the rendered rows. That's a real DRY problem, not just an isolated number to bump.

## Fix

- Extracted one exported constant, `TIME_PICKER_ROW_HEIGHT = 48`, in `style.ts`.
- Used it for all 3 style properties that previously hardcoded `42`.
- Added `lineHeight: TIME_PICKER_ROW_HEIGHT` to both label styles, so the glyph is deterministically vertically centered by its own line box instead of relying on implicit View-stretch behavior (which is exactly what OS-level font-metric changes can break).
- `view.tsx` now imports the same constant for `calculateScrollOffset`, instead of a second, independently-hardcoded `42` — one source of truth, can't drift out of sync again.

## Verified

- `npx tsc --noEmit` — 0 errors
- `npx eslint . --ext .js,.jsx,.ts,.tsx` — 0 errors (same 20 pre-existing warnings)
- `npm run test` — 18/18 suites, 100% coverage (TimePicker isn't in the coverage-gated scope, no test changes needed)

## Can't verify here

- [ ] Real Android 12+ device: digits/`:` no longer clipped.
- [ ] Tapping a specific hour/minute still scrolls the wheel to the correct row (the scroll-offset math and row height now share one constant, so this should hold, but needs a real device to confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)