### PR TITLE
Close #42: Insights chart sort already fixed, harden the DRY debt

### DIFF
--- a/src/screens/Insights/view.tsx
+++ b/src/screens/Insights/view.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { groupBy, sortBy } from 'ramda';
+import { groupBy, reverse, sortBy } from 'ramda';
 import Text from 'components/base/Text';
 import {
   View,
@@ -52,12 +52,11 @@ const InsightsView = (props: InsightsProps) => {
     }
   };
 
-  const sortByDay = sortBy(
-    (countedWalletId: typeof dailyFilteredTransactions[number]) =>
-      new Date(countedWalletId.day).getTime(),
-  );
-
-  const dailyTransactionAmountLineData = sortByDay(
+  // dailyFilteredTransactions is already sorted by paidAt, descending
+  // (most recent day first); the chart's x-axis wants ascending
+  // (oldest-to-newest), so just reverse the hook's existing order
+  // instead of re-deriving it by re-parsing the formatted day strings.
+  const dailyTransactionAmountLineData = reverse(
     dailyFilteredTransactions,
   ).map(({ day, data: currentTransactions }, index) => {
     const incoming = currentTransactions.reduce((accum, current) => {


### PR DESCRIPTION
Closes #42.

## Investigation result: not currently a bug

#42 reports "Insight chart dates are not sorted correctly / appear to sort by creation date rather than effective date." I traced the entire chart data path and found this was **already fixed upstream before this fork existed** — commit `c0e0e6f` "Fix sorting of dates" (Feb 2023, right around when `jerameel/sushi` went unmaintained, which is presumably why the issue was never closed).

Every sort/group operation in the current code already keys off `paidAt` (the user-set effective date), never `createdAt`:
- `useFilteredTransactions.ts`'s `sortTransactionByDate` and `groupByDate` both use `transaction.paidAt`.
- `useFilteredTransactions.unit.test.ts` regression-tests exactly this: its fixtures give every transaction the *same* `createdAt` while varying `paidAt`, and assert `paidAt`-ordered output — this test can only pass if `createdAt` is never the sort key.
- `Insights/view.tsx` only ever touches the hook's already-`paidAt`-sorted output.

## What I changed anyway

While confirming the above, found a real fragility nearby: `Insights/view.tsx` was re-deriving its own sort order by re-parsing the hook's already-sorted, human-formatted date strings (`'MMMM d yyyy'`) via `new Date(...).getTime()` — duplicating work the hook already did. `useFilteredTransactions` returns `dailyFilteredTransactions` sorted descending by `paidAt`; the chart wants ascending, so this now just reverses that existing order (`ramda`'s `reverse`) instead of re-deriving it from formatted strings a second time. No behavior change, just removes a duplicated, unnecessarily fragile re-computation.

## Verified

- `npx tsc --noEmit` — 0 errors
- `npx eslint . --ext .js,.jsx,.ts,.tsx` — 0 errors (same 20 pre-existing warnings)
- `npm run test` — 18/18 suites, 100% coverage (Insights isn't in the coverage-gated scope; traced the data flow by hand to confirm chart ordering is unchanged before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)