### PR TITLE
Fix #43: silent CSV export failure

### DIFF
--- a/src/components/module/Info/props.ts
+++ b/src/components/module/Info/props.ts
@@ -5,4 +5,5 @@ export interface InfoProps {
   containerStyle?: ViewStyle;
   theme?: Theme;
   label?: string;
+  status?: 'positive' | 'negative';
 }

--- a/src/components/module/Info/style.ts
+++ b/src/components/module/Info/style.ts
@@ -2,14 +2,18 @@ import { DEFAULT_THEME } from 'theme';
 import { StyleSheet } from 'react-native';
 import { Theme } from 'store/theme';
 import { getGlobalStyles, COLORS } from 'theme';
+import { InfoProps } from './props';
 
-const useStyles = (theme: Theme = DEFAULT_THEME) => {
+const useStyles = (
+  theme: Theme = DEFAULT_THEME,
+  status: InfoProps['status'] = 'positive',
+) => {
   const colors = COLORS[theme.base];
   const STYLES = getGlobalStyles(theme.base);
   const styles = StyleSheet.create({
     container: {
       padding: 16,
-      backgroundColor: colors.POSITIVE,
+      backgroundColor: status === 'negative' ? colors.ERROR : colors.POSITIVE,
     },
   });
 

--- a/src/components/module/Info/view.tsx
+++ b/src/components/module/Info/view.tsx
@@ -6,9 +6,9 @@ import Text from 'components/base/Text/view';
 import { COLORS } from 'theme';
 
 const Info = (props: InfoProps) => {
-  const { containerStyle = {}, theme, label } = props;
+  const { containerStyle = {}, theme, label, status } = props;
 
-  const { styles, colors } = useStyles(theme);
+  const { styles, colors } = useStyles(theme, status);
   return (
     <View style={[styles.container, containerStyle]}>
       <Text

--- a/src/screens/Transactions/view.tsx
+++ b/src/screens/Transactions/view.tsx
@@ -93,6 +93,12 @@ const TransactionsView = (props: TransactionsProps) => {
             theme={theme}
             label={`Transactions has been successfully exported to ${exportedFileName}`}
           />
+        ) : exportStatus === 'FAILED' ? (
+          <Info
+            theme={theme}
+            status="negative"
+            label="Export failed. Please try again."
+          />
         ) : (
           <View style={styles.actionsContainer}>
             <Button

--- a/src/services/CSV/createCSV.ts
+++ b/src/services/CSV/createCSV.ts
@@ -1,9 +1,30 @@
+import { Platform } from 'react-native';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
 // Default target directory
 const targetDirectory = `${ReactNativeBlobUtil.fs.dirs.DownloadDir}`;
 
 export const createCSV = (fileName: string, csvString: string) => {
-  const pathToWrite = `${targetDirectory}/sushi_${fileName}.csv`;
+  const targetFileName = `sushi_${fileName}.csv`;
+
+  // Android 10+ (API 29+) enforces scoped storage: writing to
+  // dirs.DownloadDir only ever reaches an app-private folder, invisible
+  // to the user. The public Downloads collection has to be written via
+  // MediaCollection, which doesn't exist pre-Q, so older Android keeps
+  // the plain path-based write below.
+  if (Platform.OS === 'android' && Platform.Version >= 29) {
+    const tempPath = `${ReactNativeBlobUtil.fs.dirs.CacheDir}/${targetFileName}`;
+    return ReactNativeBlobUtil.fs
+      .writeFile(tempPath, csvString, 'utf8')
+      .then(() =>
+        ReactNativeBlobUtil.MediaCollection.copyToMediaStore(
+          { name: targetFileName, parentFolder: '', mimeType: 'text/csv' },
+          'Download',
+          tempPath,
+        ),
+      );
+  }
+
+  const pathToWrite = `${targetDirectory}/${targetFileName}`;
   return ReactNativeBlobUtil.fs.createFile(pathToWrite, csvString, 'utf8');
 };

--- a/src/services/CSV/createCSV.unit.test.ts
+++ b/src/services/CSV/createCSV.unit.test.ts
@@ -1,15 +1,62 @@
 jest.mock('react-native-blob-util', () => ({
   fs: {
-    dirs: { DownloadDir: '/mock/downloads' },
+    dirs: { DownloadDir: '/mock/downloads', CacheDir: '/mock/cache' },
     createFile: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+  },
+  MediaCollection: {
+    copyToMediaStore: jest.fn().mockResolvedValue('content://mock-uri'),
   },
 }));
 
+jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+  __esModule: true,
+  default: { OS: 'ios', Version: '17.0' },
+}));
+
+import { Platform } from 'react-native';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { createCSV } from './createCSV';
 
+const setPlatform = (os: string, version: number | string) => {
+  const mutablePlatform = Platform as unknown as {
+    OS: string;
+    Version: number | string;
+  };
+  mutablePlatform.OS = os;
+  mutablePlatform.Version = version;
+};
+
 describe('createCSV', () => {
-  test('writes the csv string to a file in the download directory', async () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('Android 10+ (API 29+) writes to a private cache file, then copies it into the public Downloads media collection', async () => {
+    setPlatform('android', 29);
+
+    await createCSV('transactions_20240101', 'header\nrow');
+
+    expect(ReactNativeBlobUtil.fs.writeFile).toHaveBeenCalledWith(
+      '/mock/cache/sushi_transactions_20240101.csv',
+      'header\nrow',
+      'utf8',
+    );
+    expect(ReactNativeBlobUtil.MediaCollection.copyToMediaStore).toHaveBeenCalledWith(
+      {
+        name: 'sushi_transactions_20240101.csv',
+        parentFolder: '',
+        mimeType: 'text/csv',
+      },
+      'Download',
+      '/mock/cache/sushi_transactions_20240101.csv',
+    );
+    expect(ReactNativeBlobUtil.fs.createFile).not.toHaveBeenCalled();
+  });
+
+  test('Android below API 29 falls back to writing the file directly to the app download directory', async () => {
+    setPlatform('android', 28);
+
     await createCSV('transactions_20240101', 'header\nrow');
 
     expect(ReactNativeBlobUtil.fs.createFile).toHaveBeenCalledWith(
@@ -17,5 +64,19 @@ describe('createCSV', () => {
       'header\nrow',
       'utf8',
     );
+    expect(ReactNativeBlobUtil.MediaCollection.copyToMediaStore).not.toHaveBeenCalled();
+  });
+
+  test('iOS writes the csv string to a file in the download directory', async () => {
+    setPlatform('ios', '17.0');
+
+    await createCSV('transactions_20240101', 'header\nrow');
+
+    expect(ReactNativeBlobUtil.fs.createFile).toHaveBeenCalledWith(
+      '/mock/downloads/sushi_transactions_20240101.csv',
+      'header\nrow',
+      'utf8',
+    );
+    expect(ReactNativeBlobUtil.MediaCollection.copyToMediaStore).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #43.

## Two compounding bugs

**1. UI** — `Transactions/view.tsx`'s export `.catch()` set `exportStatus = 'FAILED'`, but the render logic only special-cased `'SUCCESS'`. `'FAILED'` fell through to look identical to `'IDLE'` — the spinner just disappears with no error shown. This is the literal reported symptom ("briefly shows a loading spinner and then nothing happens"), independent of whatever the underlying native failure actually is.

**2. Storage** — `createCSV.ts` wrote via `fs.createFile` to `ReactNativeBlobUtil.fs.dirs.DownloadDir`, which resolves to `Context.getExternalFilesDir(DOWNLOADS)` — an **app-private** directory, not the public Downloads folder a user would actually check in a file manager. This has never worked correctly on any Android version; Android 10+ (API 29, scoped storage) is just where it's most likely to surface as an outright native failure — matching the exact reported device (Android 10 / LineageOS 17.1).

## Fix

**UI**: Added a `status?: 'positive' | 'negative'` prop to `Info` (it was the only consumer, so this is a safe extension; defaults to `'positive'`, unchanged for the existing success case). `'negative'` maps to the theme's `ERROR` color (already defined per-theme, previously unused anywhere in the app). `Transactions/view.tsx` now renders a real error message via `Info status="negative"` when `exportStatus === 'FAILED'`, instead of silently reverting to the idle UI.

**Storage** (TDD — test updated first, confirmed failing for the right reason before implementing): `createCSV.ts` now branches on `Platform.OS === 'android' && Platform.Version >= 29`:
- **API 29+** (the exact reported case): writes the CSV to a private cache file via `fs.writeFile`, then copies it into the public Downloads collection via `MediaCollection.copyToMediaStore` — the scoped-storage-compliant API the library's own README prescribes, requiring zero new permissions.
- **iOS and Android <29**: unchanged, keeps today's `fs.createFile` behavior exactly as-is. Confirmed via `react-native-blob-util`'s native Java source (`ReactNativeBlobUtilMediaCollection.java`) that Downloads support in that API only exists on API 29+ at all — `getMediaUri` returns `null` for `MediaType.Download` below Android Q, so there's no equivalent "correct" call to make for older Android.
- Per our discussion, Android 7–9 (API 24–28) is a known, unchanged gap rather than adding `WRITE_EXTERNAL_STORAGE` to this deliberately permission-minimal app (`INTERNET` is disabled on principle per #94).

`createCSV.unit.test.ts` now covers all three branches (Android 29+, Android <29, iOS). Worth noting: mutating the real `Platform` module's `Version` in place silently no-ops in tests, because it's a getter-only property on the real `Platform.ios.js` mock with no setter — the tests mock `react-native/Libraries/Utilities/Platform` directly instead, giving a plain, fully mutable object.

## Verified

- `npx tsc --noEmit` — 0 errors
- `npx eslint . --ext .js,.jsx,.ts,.tsx` — 0 errors (same 20 pre-existing warnings)
- `npm run test` — 18/18 suites, **100% coverage maintained** on `src/services/CSV/**` (gated in CI)
- Clean `npm ci` — succeeds

## Can't verify here

- [ ] Real Android 10+ device/emulator: confirm the exported CSV actually appears in the real Downloads app/file manager (the unit test only proves the mocked call sequence, not a real MediaStore write).
- [ ] Confirm the FAILED-state error message renders correctly on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)