### PR TITLE
Redesign Phase 2: register TZS (Tanzanian Shilling) currency

### DIFF
--- a/src/infrastracture/numbro.ts
+++ b/src/infrastracture/numbro.ts
@@ -63,3 +63,62 @@ numbro.registerLanguage({
     },
   },
 });
+
+numbro.registerLanguage({
+  languageTag: 'sw-TZ',
+  delimiters: {
+    thousands: ',',
+    decimal: '.',
+  },
+  abbreviations: {
+    thousand: 'k',
+    million: 'm',
+    billion: 'b',
+    trillion: 't',
+  },
+  ordinal: (number) => {
+    let b = number % 10;
+    // eslint-disable-next-line no-bitwise
+    return ~~((number % 100) / 10) === 1
+      ? 'th'
+      : b === 1
+      ? 'st'
+      : b === 2
+      ? 'nd'
+      : b === 3
+      ? 'rd'
+      : 'th';
+  },
+  currency: {
+    position: 'prefix',
+    symbol: 'TSh',
+    code: 'TZS',
+  },
+  currencyFormat: {
+    thousandSeparated: true,
+    totalLength: 4,
+    spaceSeparated: true,
+    spaceSeparatedCurrency: true,
+    average: true,
+  },
+  formats: {
+    fourDigits: {
+      totalLength: 4,
+      spaceSeparated: true,
+      average: true,
+    },
+    fullWithTwoDecimals: {
+      thousandSeparated: true,
+      mantissa: 2,
+    },
+    fullWithTwoDecimalsNoCurrency: {
+      mantissa: 2,
+      thousandSeparated: true,
+    },
+    fullWithNoDecimals: {
+      output: 'currency',
+      thousandSeparated: true,
+      mantissa: 0,
+    },
+  },
+});


### PR DESCRIPTION
Phase 2 of 9 in implementing the "Sushi Redesign" mockup — small and independent, no dependency on Phase 1's visual changes beyond branching off the same `main`.

## What changed

The mockup uses TSh (Tanzanian Shilling) as its example currency throughout, but numbro's bundled default-languages file has no Tanzanian locale — same gap issues #46/#47 describe for INR/MYR. Registered `sw-TZ`/TZS in `src/infrastracture/numbro.ts`, mirroring the existing `fil-PH`/PHP block exactly: symbol `TSh`, prefix position, code `TZS`.

Settings' currency picker builds its option list dynamically from `numbro.languages()`, so this appears there automatically — no other code changes needed.

## A note on formatting, not a bug

Verified via a throwaway test (not committed) that `sw-TZ` formats as `TSh186500.00` — no thousands separator. Compared this against the existing `fil-PH` registration and the default `en-US`: both format identically (`₱186500.00`, `$186500.00`). This confirms the missing separator is pre-existing, universal behavior of this app's `formatCurrency` utility (`src/utils/formatCurrency.ts` doesn't pass `thousandSeparated: true` by default), not something wrong with this specific registration — and out of scope to fix here since it would affect every currency, not just this one.

## Verified

- `npx tsc --noEmit` — 0 errors
- `npx eslint . --ext .js,.jsx,.ts,.tsx` — 0 errors (same 20 pre-existing warnings)
- `npm run test` — 18/18 suites, 100% coverage maintained (this file isn't in the coverage-gated scope)
- Clean `npm ci` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)