### PR TITLE
Redesign Phase 3: bottom tab navigation shell + FAB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^3.1.1",
+        "@react-navigation/bottom-tabs": "^7.18.14",
         "@react-navigation/native": "^7.3.14",
         "@react-navigation/native-stack": "^7.18.6",
         "@reduxjs/toolkit": "^2.12.0",
@@ -4147,6 +4148,24 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.18.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.18.14.tgz",
+      "integrity": "sha512-A3V9rDSut459TBPtkD7rb0npUUBlJBfMunyRT5nOGKqPguhuXWk1h91NfQMuqyW2DCUvvFZChzsbLbj42rXTdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.36",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.3.14",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/core": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^3.1.1",
+    "@react-navigation/bottom-tabs": "^7.18.14",
     "@react-navigation/native": "^7.3.14",
     "@react-navigation/native-stack": "^7.18.6",
     "@reduxjs/toolkit": "^2.12.0",

--- a/src/components/module/Fab/index.tsx
+++ b/src/components/module/Fab/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './view';

--- a/src/components/module/Fab/props.ts
+++ b/src/components/module/Fab/props.ts
@@ -1,0 +1,8 @@
+import { ViewStyle } from 'react-native';
+import { Theme } from 'store/theme';
+
+export interface FabProps {
+  containerStyle?: ViewStyle;
+  theme?: Theme;
+  onPress?: () => void;
+}

--- a/src/components/module/Fab/style.ts
+++ b/src/components/module/Fab/style.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_THEME } from 'theme';
+import { StyleSheet } from 'react-native';
+import { Theme } from 'store/theme';
+import { COLORS } from 'theme';
+
+const FAB_SIZE = 54;
+
+const useStyles = (theme: Theme = DEFAULT_THEME) => {
+  const colors = COLORS[theme.base];
+  const styles = StyleSheet.create({
+    container: {
+      position: 'absolute',
+      right: 20,
+      bottom: 20,
+      width: FAB_SIZE,
+      height: FAB_SIZE,
+      borderRadius: FAB_SIZE / 2,
+      backgroundColor: colors.PRIMARY,
+      alignItems: 'center',
+      justifyContent: 'center',
+      shadowColor: colors.PRIMARY,
+      shadowOffset: { width: 0, height: 6 },
+      shadowOpacity: 0.3,
+      shadowRadius: 16,
+      elevation: 6,
+    },
+  });
+
+  return { styles, colors, theme };
+};
+
+export default useStyles;

--- a/src/components/module/Fab/view.tsx
+++ b/src/components/module/Fab/view.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { Plus } from 'lucide-react-native';
+import useStyles from './style';
+import { FabProps } from './props';
+
+const Fab = (props: FabProps) => {
+  const { containerStyle = {}, theme, onPress } = props;
+
+  const { styles, colors } = useStyles(theme);
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={[styles.container, containerStyle]}
+      activeOpacity={0.8}>
+      <Plus size={24} color={colors.ON_ACCENT} />
+    </TouchableOpacity>
+  );
+};
+
+export default Fab;

--- a/src/constants/translations/en-US.ts
+++ b/src/constants/translations/en-US.ts
@@ -1,5 +1,6 @@
 const en_US = {
   // DASHBOARD
+  HOME: 'Home',
   ALL: 'All',
   CREDIT: 'Credit',
   DEBIT: 'Debit',
@@ -66,6 +67,9 @@ const en_US = {
 
   // Insights
   INSIGHTS: 'Insights',
+
+  // Budgets
+  BUDGETS: 'Budgets',
 
   // Filters
   FILTERS: 'Filters',

--- a/src/constants/translations/pl-PL.ts
+++ b/src/constants/translations/pl-PL.ts
@@ -1,5 +1,6 @@
 const pl_PL = {
   // DASHBOARD
+  HOME: 'Główna',
   ALL: 'Wszystko',
   CREDIT: 'Wydatki',
   DEBIT: 'Przychody',
@@ -65,6 +66,9 @@ const pl_PL = {
 
   // Insights
   INSIGHTS: 'Analiza',
+
+  // Budgets
+  BUDGETS: 'Budżety',
 
   // Filters
   FILTERS: 'Filtry',

--- a/src/screens/Budgets/index.ts
+++ b/src/screens/Budgets/index.ts
@@ -1,0 +1,3 @@
+import BudgetsScreen from './view';
+
+export default BudgetsScreen;

--- a/src/screens/Budgets/props.ts
+++ b/src/screens/Budgets/props.ts
@@ -1,0 +1,3 @@
+import { TabScreenProps } from 'types/Route';
+
+export interface BudgetsProps extends TabScreenProps<'BUDGETS'> {}

--- a/src/screens/Budgets/styles.tsx
+++ b/src/screens/Budgets/styles.tsx
@@ -1,0 +1,26 @@
+import { StyleSheet } from 'react-native';
+import { useAppSelector } from 'store';
+import { getGlobalStyles, COLORS } from 'theme';
+
+const useStyles = () => {
+  const theme = useAppSelector((state) => state.theme);
+  const colors = COLORS[theme.base];
+  const STYLES = getGlobalStyles(theme.base);
+  const styles = StyleSheet.create({
+    container: STYLES.CONTAINER,
+    header: STYLES.HEADER,
+    content: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingHorizontal: 32,
+    },
+    body: {
+      textAlign: 'center',
+      marginTop: 8,
+    },
+  });
+  return { styles, colors, theme };
+};
+
+export default useStyles;

--- a/src/screens/Budgets/view.tsx
+++ b/src/screens/Budgets/view.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { View, StatusBar } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import useStyles from './styles';
+import { BudgetsProps } from './props';
+import Text from 'components/base/Text';
+import TextView from 'components/base/Text/view';
+
+const BudgetsView = (_props: BudgetsProps) => {
+  const { styles, theme, colors } = useStyles();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar
+        backgroundColor={colors.BACKGROUND}
+        barStyle={colors.STATUS_BAR}
+      />
+      <View style={styles.header}>
+        <Text variant="title" theme={theme} translationKey="BUDGETS" />
+      </View>
+      <View style={styles.content}>
+        <TextView variant="subtitle" theme={theme}>
+          Budgets are coming soon
+        </TextView>
+        <TextView variant="body" theme={theme} style={styles.body}>
+          Set monthly limits per category and see what's left to spend, at a
+          glance.
+        </TextView>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default BudgetsView;

--- a/src/screens/CreateTransaction/props.ts
+++ b/src/screens/CreateTransaction/props.ts
@@ -1,10 +1,10 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { CreateTransactionInput, Transactions } from 'store/transactions';
 import { Wallets } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { RootStackParamList } from 'types/Route';
 
 export interface CreateTransactionPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'CREATE_TRANSACTION'> {}
+  extends NativeStackScreenProps<RootStackParamList, 'CREATE_TRANSACTION'> {}
 
 export interface CreateTransactionPrivateProps {
   wallets: Wallets;

--- a/src/screens/CreateWallet/props.ts
+++ b/src/screens/CreateWallet/props.ts
@@ -1,9 +1,9 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { CreateWalletInput } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { RootStackParamList } from 'types/Route';
 
 export interface CreateWalletPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'CREATE_WALLET'> {}
+  extends NativeStackScreenProps<RootStackParamList, 'CREATE_WALLET'> {}
 
 export interface CreateWalletPrivateProps {
   createWallet: (payload: CreateWalletInput) => void;

--- a/src/screens/EditTransaction/props.ts
+++ b/src/screens/EditTransaction/props.ts
@@ -1,10 +1,10 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Transaction, Transactions } from 'store/transactions';
 import { Wallets } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { RootStackParamList } from 'types/Route';
 
 export interface EditTransactionPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'EDIT_TRANSACTION'> {}
+  extends NativeStackScreenProps<RootStackParamList, 'EDIT_TRANSACTION'> {}
 
 export interface EditTransactionPrivateProps {
   transaction: Transaction;

--- a/src/screens/EditWallet/props.ts
+++ b/src/screens/EditWallet/props.ts
@@ -1,9 +1,9 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Wallet } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { RootStackParamList } from 'types/Route';
 
 export interface EditWalletPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'EDIT_WALLET'> {}
+  extends NativeStackScreenProps<RootStackParamList, 'EDIT_WALLET'> {}
 
 export interface EditWalletPrivateProps {
   wallet: Wallet;

--- a/src/screens/Filters/view.tsx
+++ b/src/screens/Filters/view.tsx
@@ -12,7 +12,7 @@ import ButtonView from 'components/base/Button/view';
 import Picker from 'components/base/Picker';
 import useTranslationKey from 'utils/hooks/useTranslationKey';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { MainStackParamList } from 'types/Route';
+import { RootStackParamList } from 'types/Route';
 import { useDispatch } from 'react-redux';
 import { useAppSelector } from 'store';
 import { COLORS, getGlobalStyles } from 'theme';
@@ -31,7 +31,7 @@ export const toWalletOptions = (wallets: Wallets) => {
 };
 
 export interface FiltersProps
-  extends NativeStackScreenProps<MainStackParamList, 'FILTERS'> {}
+  extends NativeStackScreenProps<RootStackParamList, 'FILTERS'> {}
 
 const FiltersView = (props: FiltersProps) => {
   const { navigation } = props;

--- a/src/screens/Home/props.ts
+++ b/src/screens/Home/props.ts
@@ -1,10 +1,8 @@
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Transactions } from 'store/transactions';
 import { Wallets } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { TabScreenProps } from 'types/Route';
 
-export interface HomePublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'HOME'> {}
+export interface HomePublicProps extends TabScreenProps<'HOME'> {}
 
 export interface HomePrivateProps {
   wallets: Wallets;

--- a/src/screens/Home/styles.tsx
+++ b/src/screens/Home/styles.tsx
@@ -73,10 +73,6 @@ const useStyles = () => {
     transactionCard: {
       marginTop: 8,
     },
-    actionsContainer: {
-      padding: 16,
-      backgroundColor: colors.AREA_HIGHLIGHT,
-    },
     dateText: {
       color: colors.PLACE_HOLDER,
       marginTop: 12,

--- a/src/screens/Home/view.tsx
+++ b/src/screens/Home/view.tsx
@@ -17,10 +17,9 @@ import { formatCurrency } from 'utils/formatCurrency';
 import { deriveWalletBalance } from 'utils/deriveWalletBalance';
 import TextView from 'components/base/Text/view';
 import { Translation } from 'types/Translation';
-import Button from 'components/base/Button';
-import useTranslationKey from 'utils/hooks/useTranslationKey';
 import useFilteredTransactions from 'utils/hooks/useFilteredTransactions';
 import FilterButton from 'components/module/FilterButton';
+import Fab from 'components/module/Fab';
 
 const SubHeader = (props: {
   label: keyof Translation;
@@ -219,14 +218,10 @@ const HomeView = (props: HomeProps) => {
         </View>
         <View style={{ height: 32 }} />
       </ScrollView>
-      <View style={styles.actionsContainer}>
-        <Button
-          outline
-          onPress={() => navigation.navigate('CREATE_TRANSACTION')}
-          translationKey="NEW_TRANSACTION"
-          theme={theme}
-        />
-      </View>
+      <Fab
+        theme={theme}
+        onPress={() => navigation.navigate('CREATE_TRANSACTION')}
+      />
     </SafeAreaView>
   );
 };

--- a/src/screens/Insights/props.ts
+++ b/src/screens/Insights/props.ts
@@ -1,7 +1,6 @@
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Transactions } from 'store/transactions';
 import { Wallets } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { TabScreenProps } from 'types/Route';
 
 export type TransactionFilter = {
   startDate: Date | null;
@@ -9,8 +8,7 @@ export type TransactionFilter = {
   searchTerm: string;
 };
 
-export interface InsightsPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'INSIGHTS'> {}
+export interface InsightsPublicProps extends TabScreenProps<'INSIGHTS'> {}
 
 export interface InsightsPrivateProps {
   wallets: Wallets;

--- a/src/screens/Routes.tsx
+++ b/src/screens/Routes.tsx
@@ -1,83 +1,172 @@
 import { hide as hideBootSplash } from 'react-native-bootsplash';
 import React, { useEffect } from 'react';
+import { View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { MainStackParamList } from 'types/Route';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { RootStackParamList, TabParamList } from 'types/Route';
+import { useAppSelector } from 'store';
+import { COLORS } from 'theme';
+import { TranslationKey } from 'types/Translation';
+import Text from 'components/base/Text';
 import HomeScreen from './Home';
+import InsightsScreen from './Insights';
+import TransactionsScreen from './Transactions';
+import BudgetsScreen from './Budgets';
+import SettingsScreen from './Settings';
 import CreateWalletScreen from './CreateWallet';
 import EditWalletScreen from './EditWallet';
 import CreateTransactionScreen from './CreateTransaction';
 import EditTransactionScreen from './EditTransaction';
 import WalletDetailsScreen from './WalletDetails';
 import TransactionDetailsScreen from './TransactionDetails';
-import SettingsScreen from './Settings';
-import TransactionsScreen from './Transactions';
-import InsightsScreen from './Insights';
 import FiltersScreen from './Filters';
 
-const MainStack = createNativeStackNavigator<MainStackParamList>();
+const RootStack = createNativeStackNavigator<RootStackParamList>();
+const Tab = createBottomTabNavigator<TabParamList>();
+
+const TabLabel = ({
+  focused,
+  translationKey,
+}: {
+  focused: boolean;
+  translationKey: TranslationKey;
+}) => {
+  const theme = useAppSelector((state) => state.theme);
+  const colors = COLORS[theme.base];
+
+  return (
+    <View style={{ alignItems: 'center', gap: 5 }}>
+      <Text
+        variant="label"
+        theme={theme}
+        translationKey={translationKey}
+        style={{
+          textTransform: 'none',
+          letterSpacing: 0,
+          fontWeight: focused ? '600' : '400',
+          color: focused ? colors.PRIMARY_TEXT : colors.SECONDARY_TEXT,
+        }}
+      />
+      <View
+        style={{
+          width: 4,
+          height: 4,
+          borderRadius: 2,
+          backgroundColor: focused ? colors.PRIMARY : 'transparent',
+        }}
+      />
+    </View>
+  );
+};
+
+const renderHomeTabIcon = ({ focused }: { focused: boolean }) => (
+  <TabLabel focused={focused} translationKey="HOME" />
+);
+const renderInsightsTabIcon = ({ focused }: { focused: boolean }) => (
+  <TabLabel focused={focused} translationKey="INSIGHTS" />
+);
+const renderTransactionsTabIcon = ({ focused }: { focused: boolean }) => (
+  <TabLabel focused={focused} translationKey="TRANSACTIONS" />
+);
+const renderBudgetsTabIcon = ({ focused }: { focused: boolean }) => (
+  <TabLabel focused={focused} translationKey="BUDGETS" />
+);
+const renderSettingsTabIcon = ({ focused }: { focused: boolean }) => (
+  <TabLabel focused={focused} translationKey="SETTINGS" />
+);
+
+const MainTabs = () => {
+  const theme = useAppSelector((state) => state.theme);
+  const colors = COLORS[theme.base];
+
+  return (
+    <Tab.Navigator
+      initialRouteName="HOME"
+      screenOptions={{
+        headerShown: false,
+        tabBarShowLabel: false,
+        tabBarStyle: {
+          backgroundColor: colors.BACKGROUND,
+          borderTopWidth: 1,
+          borderTopColor: colors.DIVIDER,
+        },
+      }}>
+      <Tab.Screen
+        name="HOME"
+        component={HomeScreen}
+        options={{ tabBarIcon: renderHomeTabIcon }}
+      />
+      <Tab.Screen
+        name="INSIGHTS"
+        component={InsightsScreen}
+        options={{ tabBarIcon: renderInsightsTabIcon }}
+      />
+      <Tab.Screen
+        name="TRANSACTIONS"
+        component={TransactionsScreen}
+        options={{ tabBarIcon: renderTransactionsTabIcon }}
+      />
+      <Tab.Screen
+        name="BUDGETS"
+        component={BudgetsScreen}
+        options={{ tabBarIcon: renderBudgetsTabIcon }}
+      />
+      <Tab.Screen
+        name="SETTINGS"
+        component={SettingsScreen}
+        options={{ tabBarIcon: renderSettingsTabIcon }}
+      />
+    </Tab.Navigator>
+  );
+};
 
 const Routes = () => {
   useEffect(() => {
     hideBootSplash({ fade: true });
   }, []);
   return (
-    <MainStack.Navigator initialRouteName="HOME">
-      <MainStack.Screen
+    <RootStack.Navigator initialRouteName="TABS">
+      <RootStack.Screen
         options={{ headerShown: false }}
-        name="HOME"
-        component={HomeScreen}
+        name="TABS"
+        component={MainTabs}
       />
-      <MainStack.Screen
-        options={{ headerShown: false }}
-        name="TRANSACTIONS"
-        component={TransactionsScreen}
-      />
-      <MainStack.Screen
+      <RootStack.Screen
         options={{ headerShown: false }}
         name="CREATE_WALLET"
         component={CreateWalletScreen}
       />
-      <MainStack.Screen
+      <RootStack.Screen
         options={{ headerShown: false }}
         name="EDIT_WALLET"
         component={EditWalletScreen}
       />
-      <MainStack.Screen
+      <RootStack.Screen
         options={{ headerShown: false }}
         name="CREATE_TRANSACTION"
         component={CreateTransactionScreen}
       />
-      <MainStack.Screen
+      <RootStack.Screen
         options={{ headerShown: false }}
         name="EDIT_TRANSACTION"
         component={EditTransactionScreen}
       />
-      <MainStack.Screen
+      <RootStack.Screen
         options={{ headerShown: false }}
         name="WALLET_DETAILS"
         component={WalletDetailsScreen}
       />
-      <MainStack.Screen
+      <RootStack.Screen
         options={{ headerShown: false }}
         name="TRANSACTION_DETAILS"
         component={TransactionDetailsScreen}
       />
-      <MainStack.Screen
-        options={{ headerShown: false }}
-        name="SETTINGS"
-        component={SettingsScreen}
-      />
-      <MainStack.Screen
-        options={{ headerShown: false }}
-        name="INSIGHTS"
-        component={InsightsScreen}
-      />
-      <MainStack.Screen
+      <RootStack.Screen
         options={{ headerShown: false }}
         name="FILTERS"
         component={FiltersScreen}
       />
-    </MainStack.Navigator>
+    </RootStack.Navigator>
   );
 };
 

--- a/src/screens/Settings/props.ts
+++ b/src/screens/Settings/props.ts
@@ -1,10 +1,8 @@
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { THEME_OPTION } from 'store/theme';
 import { Language } from 'store/language';
-import { MainStackParamList } from 'types/Route';
+import { TabScreenProps } from 'types/Route';
 
-export interface SettingsPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'SETTINGS'> {}
+export interface SettingsPublicProps extends TabScreenProps<'SETTINGS'> {}
 
 export interface SettingsPrivateProps {
   baseTheme: string;

--- a/src/screens/TransactionDetails/props.ts
+++ b/src/screens/TransactionDetails/props.ts
@@ -1,10 +1,10 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Transaction } from 'store/transactions';
 import { Wallet } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { RootStackParamList } from 'types/Route';
 
 export interface TransactionDetailsPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'TRANSACTION_DETAILS'> {}
+  extends NativeStackScreenProps<RootStackParamList, 'TRANSACTION_DETAILS'> {}
 
 export interface TransactionDetailsPrivateProps {
   sourceWallet: Wallet;

--- a/src/screens/Transactions/props.ts
+++ b/src/screens/Transactions/props.ts
@@ -1,7 +1,6 @@
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Transactions } from 'store/transactions';
 import { Wallets } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { TabScreenProps } from 'types/Route';
 
 export type TransactionFilter = {
   startDate: Date | null;
@@ -11,7 +10,7 @@ export type TransactionFilter = {
 };
 
 export interface TransactionsPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'TRANSACTIONS'> {}
+  extends TabScreenProps<'TRANSACTIONS'> {}
 
 export interface TransactionsPrivateProps {
   wallets: Wallets;

--- a/src/screens/WalletDetails/props.ts
+++ b/src/screens/WalletDetails/props.ts
@@ -1,10 +1,10 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Transactions } from 'store/transactions';
 import { Wallet, Wallets } from 'store/wallets';
-import { MainStackParamList } from 'types/Route';
+import { RootStackParamList } from 'types/Route';
 
 export interface WalletDetailsPublicProps
-  extends NativeStackScreenProps<MainStackParamList, 'WALLET_DETAILS'> {}
+  extends NativeStackScreenProps<RootStackParamList, 'WALLET_DETAILS'> {}
 
 export interface WalletDetailsPrivateProps {
   wallet: Wallet;

--- a/src/types/Route.ts
+++ b/src/types/Route.ts
@@ -1,21 +1,31 @@
-export type MainStackParamList = {
-  HOME?: {};
-  TRANSACTIONS?: {};
-  CREATE_WALLET?: {};
-  EDIT_WALLET?: {
-    walletId: string;
-  };
-  CREATE_TRANSACTION?: {};
-  EDIT_TRANSACTION?: {
-    transactionId: string;
-  };
-  WALLET_DETAILS?: {
-    walletId: string;
-  };
-  TRANSACTION_DETAILS?: {
-    transactionId: string;
-  };
-  SETTINGS?: {};
-  INSIGHTS?: {};
-  FILTERS?: {};
+import { CompositeScreenProps, NavigatorScreenParams } from '@react-navigation/native';
+import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+export type TabParamList = {
+  HOME: undefined;
+  INSIGHTS: undefined;
+  TRANSACTIONS: undefined;
+  BUDGETS: undefined;
+  SETTINGS: undefined;
 };
+
+export type RootStackParamList = {
+  TABS: NavigatorScreenParams<TabParamList>;
+  CREATE_WALLET: undefined;
+  EDIT_WALLET: { walletId: string };
+  CREATE_TRANSACTION: undefined;
+  EDIT_TRANSACTION: { transactionId: string };
+  WALLET_DETAILS: { walletId: string };
+  TRANSACTION_DETAILS: { transactionId: string };
+  FILTERS: undefined;
+};
+
+// Tab-root screens (Home, Insights, Transactions, Budgets, Settings) can
+// navigate both to sibling tabs and to screens pushed on the enclosing
+// root stack (e.g. WALLET_DETAILS, FILTERS) — this composite type gives
+// them typed access to both instead of just their own tab navigator.
+export type TabScreenProps<T extends keyof TabParamList> = CompositeScreenProps<
+  BottomTabScreenProps<TabParamList, T>,
+  NativeStackScreenProps<RootStackParamList>
+>;


### PR DESCRIPTION
Phase 3 of 9 in implementing the "Sushi Redesign" mockup — replaces the flat native-stack with the mockup's persistent bottom tab bar (Home/Insights/Transactions/Budgets/Settings) plus a single floating action button on Home for creating a transaction.

## Navigation structure

A native-stack `RootStack` is now the true root, with a single `TABS` screen hosting a bottom-tab navigator for the 5 tab-root screens. Every other screen (wallet/transaction detail, create/edit wallet and transaction, filters) is a sibling pushed on the `RootStack`, not nested inside any one tab's own stack.

This matches the mockup's own screens exactly: frames 03–06 and 09 (the 5 tab roots) show the tab bar; frames 01/02/07/08 (onboarding, lock, wallet detail, new transaction) don't. It also avoids duplicating shared detail/edit screens across multiple tabs' stacks — React Navigation already auto-escalates `navigate()` calls up to a parent navigator when a screen name isn't found locally, so e.g. Home (a tab screen) calling `navigation.navigate('WALLET_DETAILS', ...)` just works.

Split the old flat `MainStackParamList` into `TabParamList` (the 5 tabs) and `RootStackParamList` (everything else), plus a `TabScreenProps<T>` composite type for the 5 tab-root screens (they need typed navigation to both sibling tabs and root-stack screens). The 7 root-stack-only screens just swap `MainStackParamList` → `RootStackParamList`, no other typing changes needed.

## Custom tab bar

Text label + a small dot indicator, no icons — matching the mockup's minimal tab bar treatment exactly. Defined as stable, module-scope render functions rather than inline arrow functions in each `Tab.Screen`'s `options`, specifically to avoid `react/no-unstable-nested-components` — ESLint did in fact flag the inline version when I tried it first.

## New Budgets tab

`src/screens/Budgets/`: a minimal placeholder screen (header + "coming soon" message), wired into the tab bar now so the 5-tab layout is stable across the rest of this phased rollout. Phase 7 replaces its content with the real feature — no need to touch the navigation shell again when that lands.

## FAB

`src/components/module/Fab/`: new reusable component, wired into Home in place of the old full-width bottom "New Transaction" button.

## A real gap found and fixed along the way

Added `HOME` and `BUDGETS` translation keys to `en-US.ts`. Discovered `pl-PL.ts` is the *one* locale file that doesn't spread `...en_US` — it's an independently maintained, from-scratch object literal with no type annotation — so it needed both new keys added directly too, or TypeScript's union-indexing on `TRANSLATIONS[language][key]` fails (a key must exist on every locale's inferred type, not just `en-US`'s, for that lookup to type-check). Every other locale file spreads `en_US` and picked up both keys automatically, no changes needed.

## Verified

- `npx tsc --noEmit` — 0 errors
- `npx eslint . --ext .js,.jsx,.ts,.tsx` — 0 errors, **19 warnings** (one fewer than the 20 pre-existing baseline — removing Home's now-dead `useTranslationKey` import incidentally fixed one)
- `npm run test` — 18/18 suites, 100% coverage maintained
- Clean `npm ci` — succeeds

## Can't verify here

- [ ] Tab switching actually works and feels right on a real device.
- [ ] FAB tap target size/position over real content.
- [ ] Pushed screens (wallet detail, new transaction, etc.) correctly cover the tab bar rather than rendering oddly alongside it.

Screen-level layouts still look like their pre-redesign selves — this phase is purely the navigation shell; Phase 4 does the screen-by-screen visual work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)